### PR TITLE
QC-404 Mute fairlogger console output

### DIFF
--- a/include/InfoLogger/InfoLoggerFMQ.hxx
+++ b/include/InfoLogger/InfoLoggerFMQ.hxx
@@ -83,6 +83,7 @@ void setFMQLogsToInfoLogger(AliceO2::InfoLogger::InfoLogger* logPtr = nullptr)
         atoi(metadata.line.c_str())
       };
       theLogPtr->log(opt, ctx, "FMQ: %s", content.c_str());
+      fair::Logger::SetConsoleSeverity(fair::Severity::nolog);
     });
 
   fair::Logger::SetCustomSeverity(INFOLOGGER_FMQ_SINK_NAME, fair::Logger::GetConsoleSeverity());


### PR DESCRIPTION
Mute the normal FairLogger Console output when using the redirection to infologger.