### PR TITLE
Following changes in most recent FairLogger tag using string_view instead of string

### DIFF
--- a/include/InfoLogger/InfoLogger.hxx
+++ b/include/InfoLogger/InfoLogger.hxx
@@ -242,19 +242,16 @@ class InfoLogger
     InfoLogger::Severity severity;
     int level;
     int errorCode;
-    const char* sourceFile;
+    std::string_view sourceFile;
     int sourceLine;
   };
-
-  // make sure options are a POD struct
-  static_assert(std::is_pod<InfoLoggerMessageOption>::value, "struct InfoLoggerMessageOption is not POD");
 
   /// Definition of a constant, to be used for corresponding fields when not defined
   static constexpr InfoLoggerMessageOption undefinedMessageOption = {
     Severity::Undefined, // severity
     -1,                  // level
     -1,                  // errorCode
-    nullptr,             // sourceFile
+    std::string_view(),  // sourceFile
     -1,                  // sourceLine
   };
 

--- a/include/InfoLogger/InfoLoggerFMQ.hxx
+++ b/include/InfoLogger/InfoLoggerFMQ.hxx
@@ -91,8 +91,8 @@ void setFMQLogsToInfoLogger(AliceO2::InfoLogger::InfoLogger* logPtr = nullptr)
         severity,
         level,
         AliceO2::InfoLogger::InfoLogger::undefinedMessageOption.errorCode,
-        metadata.file.c_str(),
-        atoi(metadata.line.c_str())
+        metadata.file,
+        atoi(std::string(metadata.line.data(), metadata.line.size()).c_str())
       };
       if (prefix == NULL) {
         theLogPtr->log(opt, ctx, "FMQ: %s", content.c_str());

--- a/src/InfoLogger.cxx
+++ b/src/InfoLogger.cxx
@@ -629,13 +629,7 @@ int InfoLogger::Impl::pushMessage(const InfoLoggerMessageOption& options, const 
   }
   if (options.sourceFile != undefinedMessageOption.sourceFile) {
     // trim directory path to keep it short
-    const char *shortName=options.sourceFile;
-    for (int i=(int)strlen(options.sourceFile)-1; i>=0; i--) {
-      if (options.sourceFile[i]=='/') {
-        shortName=&options.sourceFile[i+1];
-        break;
-      }
-    }
+    const char* shortName = &options.sourceFile[options.sourceFile.rfind('/') + 1];
     InfoLoggerMessageHelperSetValue(msg, msgHelper.ix_errsource, String, shortName);
   }
   if (options.sourceLine != undefinedMessageOption.sourceLine) {


### PR DESCRIPTION
FairLogger v2.1.0 introduces a new ("critical") severity to be used in O2. The previous FairLogger used was v1.11.1, so there were further changes in the meantime. One of them is changing std::string members to std::string_view members in https://github.com/FairRootGroup/FairLogger/blob/27527ad87b63213b7c58caf1e34a538e76f273da/logger/Logger.h#L176

This would also require a new InfoLogger tag, to be bumped together with FairLogger in https://github.com/alisw/alidist/pull/5763